### PR TITLE
feat: Use `gst-moq` programmatically

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,5 +32,5 @@ gst-plugin-version-helper = "0.8"
 
 [lib]
 name = "gstmoq"
-crate-type = ["cdylib"]
+crate-type = ["cdylib","rlib"]
 path = "src/lib.rs"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@ pub fn plugin_init(plugin: &gst::Plugin) -> Result<(), glib::BoolError> {
 }
 
 gst::plugin_define!(
-    moq,
+    gstmoq,
     env!("CARGO_PKG_DESCRIPTION"),
     plugin_init,
     concat!(env!("CARGO_PKG_VERSION"), "-", env!("COMMIT_ID")),


### PR DESCRIPTION
This is to help with running `moq-gst` programmatically in a rust codebase

An example:
```rust
fn main() {
    println!("Hello, world!");

    gst::init();

    gstmoq::plugin_register_static();
}
```