### PR TITLE
Add support newer transfork api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1204,19 +1204,19 @@ dependencies = [
  "moq-transfork",
  "once_cell",
  "tokio",
+ "url",
 ]
 
 [[package]]
 name = "moq-karp"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1c84b42dbdc0414b8a22f6521bbaa0fefa4913d393206803c40991d915f9e95"
+checksum = "0dd8291f9a0c82f4356ce4f330764558eee60d68e93ee22d56cda2c153337058"
 dependencies = [
  "anyhow",
  "bytes",
  "clap",
  "derive_more",
- "futures",
  "hex",
  "lazy_static",
  "moq-native",
@@ -1234,9 +1234,9 @@ dependencies = [
 
 [[package]]
 name = "moq-native"
-version = "0.5.6"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "905cc2a2193bdbe1c48d3c8f08f7044fbb5b550d720fa7572b101afee7686bde"
+checksum = "089a2cbfca0e296f9b996e01dc2e0f91010eb00384896670a503e86a1bf54e91"
 dependencies = [
  "anyhow",
  "clap",
@@ -1258,9 +1258,9 @@ dependencies = [
 
 [[package]]
 name = "moq-transfork"
-version = "0.4.3"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7bca71d1b85893f79ffc0dd9f1f25627019879ec6ae6cff398954862859f34a"
+checksum = "a41ef6c9e82bd54628e96950928d9bd818988873b6e22903d23ce6974b5333d4"
 dependencies = [
  "bytes",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,9 +14,9 @@ categories = ["multimedia", "network-programming", "web-programming"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-moq-transfork = "0.4"
-moq-native = "0.5"
-moq-karp = "0.8"
+moq-transfork = "0.6"
+moq-native = "0.5.8"
+moq-karp = "0.10"
 
 gst = { package = "gstreamer", version = "0.23" }
 gst-base = { package = "gstreamer-base", version = "0.23" }
@@ -24,6 +24,8 @@ once_cell = "1"
 tokio = { version = "1", features = ["full"] }
 env_logger = "0.9"
 anyhow = { version = "1", features = ["backtrace"] }
+
+url = "2.x"
 
 [build-dependencies]
 gst-plugin-version-helper = "0.8"

--- a/dev/pub
+++ b/dev/pub
@@ -46,6 +46,5 @@ if [ ! -f dev/bbb.fmp4 ]; then
 fi
 
 # Run gstreamer and pipe the output to moq-pub
-gst-launch-1.0 -v -e multifilesrc location="dev/bbb.fmp4" loop=true ! qtdemux name=demux \
-    demux.video_0 ! h264parse ! queue ! identity sync=true ! isofmp4mux name=mux chunk-duration=1 fragment-duration=1 ! moqsink url="$URL" broadcast="$NAME" \
-    demux.audio_0 ! aacparse ! queue ! mux.
+# (Room hardcoded for testing)
+gst-launch-1.0 -v -e multifilesrc location="dev/bbb.fmp4" loop=true ! qtdemux name=demux demux.video_0 ! h264parse ! queue ! identity sync=true ! mp4mux name=mux chunk-duration=1 fragment-duration=1 ! moqsink server="$URL" broadcast="$NAME" room="Room2" ! demux.audio_0 ! aacparse ! queue ! mux.


### PR DESCRIPTION
Good morning! 

I was taking some time using your libraries as part of Ekumen's Hackaton, sadly this plugin is broken after the recent API changes. 

I took some time to practice my noob Rust skills and try to make the existent code compatible with the new API. I'm not familiar with the `threading` Rust model, so I might be adding some things that make no sense :laugh: 

My pc is complaining about not finding the `isofmpmux` plugin, so I wasn't able to test if this is working or not. If this is close to a solution, feel free to leave comments in the code and I will be happy to iterate with you and merge it.