### PR TITLE
Fix timestamp handling and error recovery in video/audio streaming

### DIFF
--- a/src/source/imp.rs
+++ b/src/source/imp.rs
@@ -243,13 +243,12 @@ impl HangSrc {
 							let buffer_mut = buffer.get_mut().unwrap();
 
 							// Make timestamps relative to the first frame for proper playback
-							let pts = if reference.is_none() {
+							let pts = if let Some(reference_ts) = reference {
+								let timestamp: std::time::Duration = frame.timestamp - reference_ts;
+								gst::ClockTime::from_nseconds(timestamp.as_nanos() as _)
+							} else {
 								reference = Some(frame.timestamp);
 								gst::ClockTime::ZERO
-							} else {
-								let reference_ts = reference.unwrap();
-								let timestamp = frame.timestamp - reference_ts;
-								gst::ClockTime::from_nseconds(timestamp.as_nanos() as _)
 							};
 							buffer_mut.set_pts(Some(pts));
 
@@ -348,13 +347,12 @@ impl HangSrc {
 							let buffer_mut = buffer.get_mut().unwrap();
 
 							// Make timestamps relative to the first frame for proper playback
-							let pts = if reference.is_none() {
+							let pts = if let Some(reference_ts) = reference {
+								let timestamp: std::time::Duration = frame.timestamp - reference_ts;
+								gst::ClockTime::from_nseconds(timestamp.as_nanos() as _)
+							} else {
 								reference = Some(frame.timestamp);
 								gst::ClockTime::ZERO
-							} else {
-								let reference_ts = reference.unwrap();
-								let timestamp = frame.timestamp - reference_ts;
-								gst::ClockTime::from_nseconds(timestamp.as_nanos() as _)
 							};
 							buffer_mut.set_pts(Some(pts));
 


### PR DESCRIPTION
- Fix timestamp calculation to make timestamps relative to first frame (PTS starts at 0)
- Replace panic-prone error handling with graceful error recovery for failed frame reads
- Add proper handling for stream end and connection errors in both video and audio tracks
- Log warnings instead of panicking on connection errors, allowing streams to terminate gracefully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added user-facing helper scripts to capture snapshots, run a test broadcast pipeline, and view streams locally.

* **Improvements**
  * Per-source runtime isolation for more reliable background processing and clearer end-of-stream behavior.
  * Smoother playback timing by normalizing timestamps to start from zero and more consistent frame/keyframe handling.

* **Bug Fixes**
  * Prevents crashes by gracefully handling read errors during streaming.
  * Properly stops processing at end-of-stream without unexpected failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->