### PR TITLE
feat: add nix flake package and dev-shell

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,98 @@
+{
+  "nodes": {
+    "crane": {
+      "locked": {
+        "lastModified": 1762538466,
+        "narHash": "sha256-8zrIPl6J+wLm9MH5ksHcW7BUHo7jSNOu0/hA0ohOOaM=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "0cea393fffb39575c46b7a0318386467272182fe",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1762977756,
+        "narHash": "sha256-4PqRErxfe+2toFJFgcRKZ0UI9NSIOJa+7RXVtBhy4KE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "c5ae371f1a6a7fd27823bc500d9390b38c05fa55",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "crane": "crane",
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1763260832,
+        "narHash": "sha256-KMEJ9S7bZLvDIfVu2XdEJTZVYAc/arjFt5KnhGqwCOg=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "c3cea2a0ec0d5debbef4aa2a0cfe59bd0fb0aeeb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,88 @@
+{
+  description = "Media over QUIC - Gstreamer plugin";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+    crane.url = "github:ipetkov/crane";
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs = { self, nixpkgs, flake-utils, crane, rust-overlay}: 
+      flake-utils.lib.eachDefaultSystem (
+        system:
+        let
+          pkgs = import nixpkgs {
+            inherit system;
+            overlays = [ (import rust-overlay) ];
+          };
+          rust-toolchain = pkgs.rust-bin.stable.latest.default.override {
+            extensions = [
+              "rust-src"
+              "rust-analyzer"
+            ];
+          };
+         craneLib = (crane.mkLib pkgs).overrideToolchain rust-toolchain;
+
+          # Helper function to get crate info from Cargo.toml
+          crateInfo = cargoTomlPath: craneLib.crateNameFromCargoToml { cargoToml = cargoTomlPath; };
+          
+          gstreamerLib = with pkgs ; [
+            gst_all_1.gstreamer.out
+            gst_all_1.gst-plugins-base
+            gst_all_1.gst-plugins-good
+            gst_all_1.gst-plugins-bad
+          ];
+          gstreamerSearch = with pkgs; [
+            gst_all_1.gst-plugins-ugly
+            gst_all_1.gst-plugins-rs
+          ] ++ gstreamerLib;
+
+          shell-deps = with pkgs; [
+            rust-toolchain
+            just
+            pkg-config
+            glib
+            cargo-sort
+            cargo-shear
+            cargo-edit
+            gst_all_1.gstreamer
+          ];
+
+          gstPluginPath = nixpkgs.lib.makeSearchPath "lib/gstreamer-1.0" gstreamerSearch + ":" + nixpkgs.lib.makeLibraryPath gstreamerLib;
+        in {
+          devShell = pkgs.mkShell {
+            packages = shell-deps;
+
+            env = {
+              GST_PLUGIN_PATH_1_0 = gstPluginPath;
+              #PKG_CONFIG_PATH = pkgConfigPath;
+              GST_REGISTRY = "./gst-registry.bin";
+            };
+
+            # if you want zsh instead of bash, uncomment this
+            #shellHook = ''
+            #  exec zsh
+            #'';
+          };
+          packages = {
+            hang-gst = craneLib.buildPackage (
+              crateInfo ./Cargo.toml
+              // {
+                src = craneLib.cleanCargoSource ./.;
+                nativeBuildInputs = with pkgs; [
+                  pkg-config
+                  glib
+                  glib.dev
+                  gst_all_1.gstreamer.dev
+                ];
+                cargoExtraArgs = "-p hang-gst";
+              }
+            );
+            default = self.packages.${system}.hang-gst;
+          };
+        });
+}


### PR DESCRIPTION
this is an inital attempt at creating a dev-shell for this. i am unsure if all dependencies are present.
I've included (almost) all gstreamer plugins, so its easier to test pipelines, but i'm also unsure if this is needed.
this will also conflict with gstreamer installed e.g. via homebrew (tested on macos), my short solution to this was to uninstall the version from homebrew

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added development environment setup for the Media over QUIC - Gstreamer plugin project, enabling developers to build and run the plugin with all necessary dependencies configured automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->